### PR TITLE
fix: resolve compilation error

### DIFF
--- a/example/demo.cpp
+++ b/example/demo.cpp
@@ -1,6 +1,6 @@
-#include "cpp-semver.hpp"
-
 #include <iostream>
+
+#include "cpp-semver.hpp"
 
 int main()
 {


### PR DESCRIPTION
Not 100% sure why this is happening, but it fixes the error below:

```
In file included from include/cpp-semver.hpp:4,
                 from example/demo.cpp:1:
include/base/type.hpp:12:3: error: expected class-name before '{' token
   12 |   {
      |   ^
include/base/type.hpp: In constructor 'semver::semver_error::semver_error(const string&)':
include/base/type.hpp:13:62: error: expected class-name before '(' token
   13 |     semver_error(const std::string& msg) : std::runtime_error(msg) {}
      |                                                              ^
include/base/type.hpp:13:62: error: expected '{' before '(' token
include/base/type.hpp:13:37: error: unused parameter 'msg' [-Werror=unused-parameter]
   13 |     semver_error(const std::string& msg) : std::runtime_error(msg) {}
      |                  ~~~~~~~~~~~~~~~~~~~^~~
cc1plus: all warnings being treated as errors
make: *** [Makefile:72: build/debug/no_pegtl/example/demo] Error 1
```